### PR TITLE
Remove margin below last paragraph in metadata content

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -408,3 +408,6 @@ body.contrast-high .goal.reporting-status-item {
 body.contrast-high .goal-stats span.complete {
     background-color: white !important;
 }
+.metadata-content td p:last-child {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
This is an example of how to use custom CSS to remove spacing below metadata content. We'll also try to get this into Open SDG: https://github.com/open-sdg/open-sdg/issues/2225