### PR TITLE
Capitalize the first letter of the sidebar/footnote disaggregations

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -408,3 +408,7 @@ body.contrast-high .goal.reporting-status-item {
 body.contrast-high .goal-stats span.complete {
     background-color: white !important;
 }
+#selectionChartFooter dt::first-letter,
+#fields .variable-selector h5::first-letter {
+    text-transform: capitalize;
+}


### PR DESCRIPTION
This is an example of custom CSS to capitalize the first letter of data disaggregations in the footnote and sidebar.